### PR TITLE
Add link to #rust-sci in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Dependencies status](https://deps.rs/repo/github/jturner314/ndarray-stats/status.svg)](https://deps.rs/repo/github/jturner314/ndarray-stats)
 [![Crate](https://img.shields.io/crates/v/ndarray-stats.svg)](https://crates.io/crates/ndarray-stats)
 [![Documentation](https://docs.rs/ndarray-stats/badge.svg)](https://docs.rs/ndarray-stats)
+[![Chat](https://img.shields.io/badge/chat-%23rust--sci-lightgrey.svg)](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-sci)
 
 This crate provides statistical methods for [`ndarray`]'s `ArrayBase` type.
 


### PR DESCRIPTION
It's helpful to have a place for users to chat. The link is to #rust-sci in the Mibbit client (the same client used for the "Mozilla IRC" link on https://www.rust-lang.org/community). Mibbit is nice because it provides a way for people to join the chat using their browser without even having to register.