### PR TITLE
Update URLs from jturner314 to rust-ndarray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 license = "MIT/Apache-2.0"
 
-repository = "https://github.com/jturner314/ndarray-stats"
+repository = "https://github.com/rust-ndarray/ndarray-stats"
 documentation = "https://docs.rs/ndarray-stats/"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ndarray-stats
 
-[![Build status](https://travis-ci.org/jturner314/ndarray-stats.svg?branch=master)](https://travis-ci.org/jturner314/ndarray-stats)
-[![Coverage](https://codecov.io/gh/jturner314/ndarray-stats/branch/master/graph/badge.svg)](https://codecov.io/gh/jturner314/ndarray-stats)
-[![Dependencies status](https://deps.rs/repo/github/jturner314/ndarray-stats/status.svg)](https://deps.rs/repo/github/jturner314/ndarray-stats)
+[![Build status](https://travis-ci.org/rust-ndarray/ndarray-stats.svg?branch=master)](https://travis-ci.org/rust-ndarray/ndarray-stats)
+[![Coverage](https://codecov.io/gh/rust-ndarray/ndarray-stats/branch/master/graph/badge.svg)](https://codecov.io/gh/rust-ndarray/ndarray-stats)
+[![Dependencies status](https://deps.rs/repo/github/rust-ndarray/ndarray-stats/status.svg)](https://deps.rs/repo/github/rust-ndarray/ndarray-stats)
 [![Crate](https://img.shields.io/crates/v/ndarray-stats.svg)](https://crates.io/crates/ndarray-stats)
 [![Documentation](https://docs.rs/ndarray-stats/badge.svg)](https://docs.rs/ndarray-stats)
 
@@ -18,7 +18,7 @@ Currently available routines include:
 
 See the [documentation](https://docs.rs/ndarray-stats) for more information.
 
-Please feel free to contribute new functionality! A roadmap can be found [here](https://github.com/jturner314/ndarray-stats/issues/1).
+Please feel free to contribute new functionality! A roadmap can be found [here](https://github.com/rust-ndarray/ndarray-stats/issues/1).
 
 [`ndarray`]: https://github.com/rust-ndarray/ndarray
 
@@ -58,7 +58,7 @@ ndarray-stats = "0.2"
 
   *Contributors*: [@jturner314](https://github.com/jturner314), [@LukeMathWalker](https://github.com/LukeMathWalker), [@phungleson](https://github.com/phungleson), [@munckymagik](https://github.com/munckymagik)
 
-  [#34]: https://github.com/jturner314/ndarray-stats/issues/34
+  [#34]: https://github.com/rust-ndarray/ndarray-stats/issues/34
 
 * **0.1.0**
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! [`NumPy`] (Python) and [`StatsBase.jl`] (Julia) - any contribution bringing us closer to
 //! feature parity is more than welcome!
 //!
-//! [`ndarray-stats`]: https://github.com/jturner314/ndarray-stats/
+//! [`ndarray-stats`]: https://github.com/rust-ndarray/ndarray-stats/
 //! [`ndarray`]: https://github.com/rust-ndarray/ndarray
 //! [order statistics]: trait.QuantileExt.html
 //! [partitioning]: trait.Sort1dExt.html
@@ -23,7 +23,7 @@
 //! [correlation analysis]: trait.CorrelationExt.html
 //! [measures from information theory]: trait.EntropyExt.html
 //! [histogram computation]: histogram/index.html
-//! [here]: https://github.com/jturner314/ndarray-stats/issues/1
+//! [here]: https://github.com/rust-ndarray/ndarray-stats/issues/1
 //! [`NumPy`]: https://docs.scipy.org/doc/numpy-1.14.1/reference/routines.statistics.html
 //! [`StatsBase.jl`]: https://juliastats.github.io/StatsBase.jl/latest/
 


### PR DESCRIPTION
The repository was renamed from `jturner314/ndarray-stats` to `rust-ndarray/ndarray-stats`. This is related to #44.