### PR TITLE
Improve coverage testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ script: |
   cargo test
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-    cargo tarpaulin --out Xml
+    cargo tarpaulin --run-types Tests Doctests --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - rust: nightly
 before_cache: |
   if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
+    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin -f
   fi
 before_script:
 - rustup component add rustfmt


### PR DESCRIPTION
The `tarpaulin` README says "Because of the use of nightly proc-macro features you'll need to reinstall tarpaulin each time unless you're keeping to a specific nightly version. If you are keeping to a specific nightly you can remove the `-f` flag in the example travis file."

We haven't pinned a nightly version, so we should use the `-f` option.