### PR TITLE
Deviation - Allow mixed ownership

### DIFF
--- a/src/deviation.rs
+++ b/src/deviation.rs
@@ -19,9 +19,10 @@ where
     ///
     /// * `MultiInputError::EmptyInput` if `self` is empty
     /// * `MultiInputError::ShapeMismatch` if `self` and `other` don't have the same shape
-    fn count_eq(&self, other: &ArrayBase<S, D>) -> Result<usize, MultiInputError>
+    fn count_eq<T>(&self, other: &ArrayBase<T, D>) -> Result<usize, MultiInputError>
     where
-        A: PartialEq;
+        A: PartialEq,
+        T: Data<Elem = A>;
 
     /// Counts the number of indices at which the elements of the arrays `self`
     /// and `other` are not equal.
@@ -30,9 +31,10 @@ where
     ///
     /// * `MultiInputError::EmptyInput` if `self` is empty
     /// * `MultiInputError::ShapeMismatch` if `self` and `other` don't have the same shape
-    fn count_neq(&self, other: &ArrayBase<S, D>) -> Result<usize, MultiInputError>
+    fn count_neq<T>(&self, other: &ArrayBase<T, D>) -> Result<usize, MultiInputError>
     where
-        A: PartialEq;
+        A: PartialEq,
+        T: Data<Elem = A>;
 
     /// Computes the [squared L2 distance] between `self` and `other`.
     ///
@@ -50,9 +52,10 @@ where
     /// * `MultiInputError::ShapeMismatch` if `self` and `other` don't have the same shape
     ///
     /// [squared L2 distance]: https://en.wikipedia.org/wiki/Euclidean_distance#Squared_Euclidean_distance
-    fn sq_l2_dist(&self, other: &ArrayBase<S, D>) -> Result<A, MultiInputError>
+    fn sq_l2_dist<T>(&self, other: &ArrayBase<T, D>) -> Result<A, MultiInputError>
     where
-        A: AddAssign + Clone + Signed;
+        A: AddAssign + Clone + Signed,
+        T: Data<Elem = A>;
 
     /// Computes the [L2 distance] between `self` and `other`.
     ///
@@ -72,9 +75,10 @@ where
     /// **Panics** if the type cast from `A` to `f64` fails.
     ///
     /// [L2 distance]: https://en.wikipedia.org/wiki/Euclidean_distance
-    fn l2_dist(&self, other: &ArrayBase<S, D>) -> Result<f64, MultiInputError>
+    fn l2_dist<T>(&self, other: &ArrayBase<T, D>) -> Result<f64, MultiInputError>
     where
-        A: AddAssign + Clone + Signed + ToPrimitive;
+        A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>;
 
     /// Computes the [L1 distance] between `self` and `other`.
     ///
@@ -92,9 +96,10 @@ where
     /// * `MultiInputError::ShapeMismatch` if `self` and `other` don't have the same shape
     ///
     /// [L1 distance]: https://en.wikipedia.org/wiki/Taxicab_geometry
-    fn l1_dist(&self, other: &ArrayBase<S, D>) -> Result<A, MultiInputError>
+    fn l1_dist<T>(&self, other: &ArrayBase<T, D>) -> Result<A, MultiInputError>
     where
-        A: AddAssign + Clone + Signed;
+        A: AddAssign + Clone + Signed,
+        T: Data<Elem = A>;
 
     /// Computes the [L∞ distance] between `self` and `other`.
     ///
@@ -111,9 +116,10 @@ where
     /// * `MultiInputError::ShapeMismatch` if `self` and `other` don't have the same shape
     ///
     /// [L∞ distance]: https://en.wikipedia.org/wiki/Chebyshev_distance
-    fn linf_dist(&self, other: &ArrayBase<S, D>) -> Result<A, MultiInputError>
+    fn linf_dist<T>(&self, other: &ArrayBase<T, D>) -> Result<A, MultiInputError>
     where
-        A: Clone + PartialOrd + Signed;
+        A: Clone + PartialOrd + Signed,
+        T: Data<Elem = A>;
 
     /// Computes the [mean absolute error] between `self` and `other`.
     ///
@@ -133,9 +139,10 @@ where
     /// **Panics** if the type cast from `A` to `f64` fails.
     ///
     /// [mean absolute error]: https://en.wikipedia.org/wiki/Mean_absolute_error
-    fn mean_abs_err(&self, other: &ArrayBase<S, D>) -> Result<f64, MultiInputError>
+    fn mean_abs_err<T>(&self, other: &ArrayBase<T, D>) -> Result<f64, MultiInputError>
     where
-        A: AddAssign + Clone + Signed + ToPrimitive;
+        A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>;
 
     /// Computes the [mean squared error] between `self` and `other`.
     ///
@@ -155,9 +162,10 @@ where
     /// **Panics** if the type cast from `A` to `f64` fails.
     ///
     /// [mean squared error]: https://en.wikipedia.org/wiki/Mean_squared_error
-    fn mean_sq_err(&self, other: &ArrayBase<S, D>) -> Result<f64, MultiInputError>
+    fn mean_sq_err<T>(&self, other: &ArrayBase<T, D>) -> Result<f64, MultiInputError>
     where
-        A: AddAssign + Clone + Signed + ToPrimitive;
+        A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>;
 
     /// Computes the unnormalized [root-mean-square error] between `self` and `other`.
     ///
@@ -175,9 +183,10 @@ where
     /// **Panics** if the type cast from `A` to `f64` fails.
     ///
     /// [root-mean-square error]: https://en.wikipedia.org/wiki/Root-mean-square_deviation
-    fn root_mean_sq_err(&self, other: &ArrayBase<S, D>) -> Result<f64, MultiInputError>
+    fn root_mean_sq_err<T>(&self, other: &ArrayBase<T, D>) -> Result<f64, MultiInputError>
     where
-        A: AddAssign + Clone + Signed + ToPrimitive;
+        A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>;
 
     /// Computes the [peak signal-to-noise ratio] between `self` and `other`.
     ///
@@ -196,13 +205,14 @@ where
     /// **Panics** if the type cast from `A` to `f64` fails.
     ///
     /// [peak signal-to-noise ratio]: https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
-    fn peak_signal_to_noise_ratio(
+    fn peak_signal_to_noise_ratio<T>(
         &self,
-        other: &ArrayBase<S, D>,
+        other: &ArrayBase<T, D>,
         maxv: A,
     ) -> Result<f64, MultiInputError>
     where
-        A: AddAssign + Clone + Signed + ToPrimitive;
+        A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>;
 
     private_decl! {}
 }
@@ -231,9 +241,10 @@ where
     S: Data<Elem = A>,
     D: Dimension,
 {
-    fn count_eq(&self, other: &ArrayBase<S, D>) -> Result<usize, MultiInputError>
+    fn count_eq<T>(&self, other: &ArrayBase<T, D>) -> Result<usize, MultiInputError>
     where
         A: PartialEq,
+        T: Data<Elem = A>,
     {
         return_err_if_empty!(self);
         return_err_unless_same_shape!(self, other);
@@ -249,16 +260,18 @@ where
         Ok(count)
     }
 
-    fn count_neq(&self, other: &ArrayBase<S, D>) -> Result<usize, MultiInputError>
+    fn count_neq<T>(&self, other: &ArrayBase<T, D>) -> Result<usize, MultiInputError>
     where
         A: PartialEq,
+        T: Data<Elem = A>,
     {
         self.count_eq(other).map(|n_eq| self.len() - n_eq)
     }
 
-    fn sq_l2_dist(&self, other: &ArrayBase<S, D>) -> Result<A, MultiInputError>
+    fn sq_l2_dist<T>(&self, other: &ArrayBase<T, D>) -> Result<A, MultiInputError>
     where
         A: AddAssign + Clone + Signed,
+        T: Data<Elem = A>,
     {
         return_err_if_empty!(self);
         return_err_unless_same_shape!(self, other);
@@ -274,9 +287,10 @@ where
         Ok(result)
     }
 
-    fn l2_dist(&self, other: &ArrayBase<S, D>) -> Result<f64, MultiInputError>
+    fn l2_dist<T>(&self, other: &ArrayBase<T, D>) -> Result<f64, MultiInputError>
     where
         A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>,
     {
         let sq_l2_dist = self
             .sq_l2_dist(other)?
@@ -286,9 +300,10 @@ where
         Ok(sq_l2_dist.sqrt())
     }
 
-    fn l1_dist(&self, other: &ArrayBase<S, D>) -> Result<A, MultiInputError>
+    fn l1_dist<T>(&self, other: &ArrayBase<T, D>) -> Result<A, MultiInputError>
     where
         A: AddAssign + Clone + Signed,
+        T: Data<Elem = A>,
     {
         return_err_if_empty!(self);
         return_err_unless_same_shape!(self, other);
@@ -303,9 +318,10 @@ where
         Ok(result)
     }
 
-    fn linf_dist(&self, other: &ArrayBase<S, D>) -> Result<A, MultiInputError>
+    fn linf_dist<T>(&self, other: &ArrayBase<T, D>) -> Result<A, MultiInputError>
     where
         A: Clone + PartialOrd + Signed,
+        T: Data<Elem = A>,
     {
         return_err_if_empty!(self);
         return_err_unless_same_shape!(self, other);
@@ -323,9 +339,10 @@ where
         Ok(max)
     }
 
-    fn mean_abs_err(&self, other: &ArrayBase<S, D>) -> Result<f64, MultiInputError>
+    fn mean_abs_err<T>(&self, other: &ArrayBase<T, D>) -> Result<f64, MultiInputError>
     where
         A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>,
     {
         let l1_dist = self
             .l1_dist(other)?
@@ -336,9 +353,10 @@ where
         Ok(l1_dist / n)
     }
 
-    fn mean_sq_err(&self, other: &ArrayBase<S, D>) -> Result<f64, MultiInputError>
+    fn mean_sq_err<T>(&self, other: &ArrayBase<T, D>) -> Result<f64, MultiInputError>
     where
         A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>,
     {
         let sq_l2_dist = self
             .sq_l2_dist(other)?
@@ -349,21 +367,23 @@ where
         Ok(sq_l2_dist / n)
     }
 
-    fn root_mean_sq_err(&self, other: &ArrayBase<S, D>) -> Result<f64, MultiInputError>
+    fn root_mean_sq_err<T>(&self, other: &ArrayBase<T, D>) -> Result<f64, MultiInputError>
     where
         A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>,
     {
         let msd = self.mean_sq_err(other)?;
         Ok(msd.sqrt())
     }
 
-    fn peak_signal_to_noise_ratio(
+    fn peak_signal_to_noise_ratio<T>(
         &self,
-        other: &ArrayBase<S, D>,
+        other: &ArrayBase<T, D>,
         maxv: A,
     ) -> Result<f64, MultiInputError>
     where
         A: AddAssign + Clone + Signed + ToPrimitive,
+        T: Data<Elem = A>,
     {
         let maxv_f = maxv.to_f64().expect("failed cast from type A to f64");
         let msd = self.mean_sq_err(&other)?;

--- a/tests/deviation.rs
+++ b/tests/deviation.rs
@@ -12,12 +12,12 @@ use std::f64;
 fn test_count_eq() -> Result<(), MultiInputError> {
     let a = array![0., 0.];
     let b = array![1., 0.];
-    let c = array![0., 1.];
+    let mut c = array![0., 1.];
     let d = array![1., 1.];
 
     assert_eq!(a.count_eq(&a)?, 2);
-    assert_eq!(a.count_eq(&b)?, 1);
-    assert_eq!(a.count_eq(&c)?, 1);
+    assert_eq!(a.count_eq(&b.view())?, 1);
+    assert_eq!(a.count_eq(&c.view_mut())?, 1);
     assert_eq!(a.count_eq(&d)?, 0);
 
     Ok(())
@@ -27,12 +27,12 @@ fn test_count_eq() -> Result<(), MultiInputError> {
 fn test_count_neq() -> Result<(), MultiInputError> {
     let a = array![0., 0.];
     let b = array![1., 0.];
-    let c = array![0., 1.];
+    let mut c = array![0., 1.];
     let d = array![1., 1.];
 
     assert_eq!(a.count_neq(&a)?, 0);
-    assert_eq!(a.count_neq(&b)?, 1);
-    assert_eq!(a.count_neq(&c)?, 1);
+    assert_eq!(a.count_neq(&b.view())?, 1);
+    assert_eq!(a.count_neq(&c.view_mut())?, 1);
     assert_eq!(a.count_neq(&d)?, 2);
 
     Ok(())
@@ -41,9 +41,11 @@ fn test_count_neq() -> Result<(), MultiInputError> {
 #[test]
 fn test_sq_l2_dist() -> Result<(), MultiInputError> {
     let a = array![0., 1., 4., 2.];
-    let b = array![1., 1., 2., 4.];
+    let mut b = array![1., 1., 2., 4.];
 
     assert_eq!(a.sq_l2_dist(&b)?, 9.);
+    assert_eq!(a.sq_l2_dist(&b.view())?, 9.);
+    assert_eq!(a.sq_l2_dist(&b.view_mut())?, 9.);
 
     Ok(())
 }
@@ -51,9 +53,11 @@ fn test_sq_l2_dist() -> Result<(), MultiInputError> {
 #[test]
 fn test_l2_dist() -> Result<(), MultiInputError> {
     let a = array![0., 1., 4., 2.];
-    let b = array![1., 1., 2., 4.];
+    let mut b = array![1., 1., 2., 4.];
 
     assert_eq!(a.l2_dist(&b)?, 3.);
+    assert_eq!(a.l2_dist(&b.view())?, 3.);
+    assert_eq!(a.l2_dist(&b.view_mut())?, 3.);
 
     Ok(())
 }
@@ -61,9 +65,11 @@ fn test_l2_dist() -> Result<(), MultiInputError> {
 #[test]
 fn test_l1_dist() -> Result<(), MultiInputError> {
     let a = array![0., 1., 4., 2.];
-    let b = array![1., 1., 2., 4.];
+    let mut b = array![1., 1., 2., 4.];
 
     assert_eq!(a.l1_dist(&b)?, 5.);
+    assert_eq!(a.l1_dist(&b.view())?, 5.);
+    assert_eq!(a.l1_dist(&b.view_mut())?, 5.);
 
     Ok(())
 }
@@ -71,15 +77,15 @@ fn test_l1_dist() -> Result<(), MultiInputError> {
 #[test]
 fn test_linf_dist() -> Result<(), MultiInputError> {
     let a = array![0., 0.];
-    let b = array![1., 0.];
+    let mut b = array![1., 0.];
     let c = array![1., 2.];
 
     assert_eq!(a.linf_dist(&a)?, 0.);
 
-    assert_eq!(a.linf_dist(&b)?, 1.);
+    assert_eq!(a.linf_dist(&b.view_mut())?, 1.);
     assert_eq!(b.linf_dist(&a)?, 1.);
 
-    assert_eq!(a.linf_dist(&c)?, 2.);
+    assert_eq!(a.linf_dist(&c.view())?, 2.);
     assert_eq!(c.linf_dist(&a)?, 2.);
 
     Ok(())
@@ -88,10 +94,10 @@ fn test_linf_dist() -> Result<(), MultiInputError> {
 #[test]
 fn test_mean_abs_err() -> Result<(), MultiInputError> {
     let a = array![1., 1.];
-    let b = array![3., 5.];
+    let mut b = array![3., 5.];
 
-    assert_eq!(a.mean_abs_err(&a)?, 0.);
-    assert_eq!(a.mean_abs_err(&b)?, 3.);
+    assert_eq!(a.mean_abs_err(&a.view())?, 0.);
+    assert_eq!(a.mean_abs_err(&b.view_mut())?, 3.);
     assert_eq!(b.mean_abs_err(&a)?, 3.);
 
     Ok(())
@@ -100,11 +106,11 @@ fn test_mean_abs_err() -> Result<(), MultiInputError> {
 #[test]
 fn test_mean_sq_err() -> Result<(), MultiInputError> {
     let a = array![1., 1.];
-    let b = array![3., 5.];
+    let mut b = array![3., 5.];
 
     assert_eq!(a.mean_sq_err(&a)?, 0.);
-    assert_eq!(a.mean_sq_err(&b)?, 10.);
-    assert_eq!(b.mean_sq_err(&a)?, 10.);
+    assert_eq!(a.mean_sq_err(&b.view_mut())?, 10.);
+    assert_eq!(b.mean_sq_err(&a.view())?, 10.);
 
     Ok(())
 }
@@ -112,10 +118,10 @@ fn test_mean_sq_err() -> Result<(), MultiInputError> {
 #[test]
 fn test_root_mean_sq_err() -> Result<(), MultiInputError> {
     let a = array![1., 1.];
-    let b = array![3., 5.];
+    let mut b = array![3., 5.];
 
-    assert_eq!(a.root_mean_sq_err(&a)?, 0.);
-    assert_abs_diff_eq!(a.root_mean_sq_err(&b)?, 10.0.sqrt());
+    assert_eq!(a.root_mean_sq_err(&a.view())?, 0.);
+    assert_abs_diff_eq!(a.root_mean_sq_err(&b.view_mut())?, 10.0.sqrt());
     assert_abs_diff_eq!(b.root_mean_sq_err(&a)?, 10.0.sqrt());
 
     Ok(())
@@ -130,7 +136,7 @@ fn test_peak_signal_to_noise_ratio() -> Result<(), MultiInputError> {
     let b = array![1., 3., 3., 4., 6., 7., 8.];
     let maxv = 8.;
     let expected = 20. * Float::log10(maxv) - 10. * Float::log10(a.mean_sq_err(&b)?);
-    let actual = a.peak_signal_to_noise_ratio(&b, maxv)?;
+    let actual = a.peak_signal_to_noise_ratio(&b.view(), maxv)?;
 
     assert_abs_diff_eq!(actual, expected);
 


### PR DESCRIPTION
Small change to allow deviation measures to be computed for pairs of arrays with different ownership over their data.

This snippet
```rust
let a = array![0., 0.];
let b = array![1., 0.];

assert_eq!(a.count_eq(&b.view())?, 1);
```
does not compile on master, but it does on this branch.

I bumped on this limitation while working on a k-means example (https://github.com/rust-ndarray/ndarray-examples/commit/4e4692af00d86eda5f0e2f731a6062689977d7a9 - `find_closest_centroid`).