### PR TITLE
Use the latest rand and ndarray-rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ ndarray = "0.12.1"
 noisy_float = "0.1.8"
 num-integer = "0.1"
 num-traits = "0.2"
-rand = "0.6"
+rand = "0.7"
 itertools = { version = "0.8.0", default-features = false }
 indexmap = "1.0"
 
 [dev-dependencies]
 criterion = "0.2"
 quickcheck = { version = "0.8.1", default-features = false }
-ndarray-rand = "0.9"
+ndarray-rand = "0.10"
 approx = "0.3"
 quickcheck_macros = "0.8"
 num-bigint = "0.2.2"

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -340,5 +340,4 @@ mod pearson_correlation_tests {
         assert_eq!(a.ndim(), 2);
         assert!(a.pearson_correlation().all_close(&numpy_corrcoeff, 1e-7));
     }
-
 }


### PR DESCRIPTION
Some house keeping.
It reduces the number of different versions of `rand` that a user has to compile in order to use the latest `ndarray-rand` together with `ndarray-stats`.