### PR TITLE
Weighted mean

### DIFF
--- a/src/deviation.rs
+++ b/src/deviation.rs
@@ -3,7 +3,7 @@ use num_traits::{Signed, ToPrimitive};
 use std::convert::Into;
 use std::ops::AddAssign;
 
-use crate::errors::{MultiInputError, ShapeMismatch};
+use crate::errors::MultiInputError;
 
 /// An extension trait for `ArrayBase` providing functions
 /// to compute different deviation measures.
@@ -215,25 +215,6 @@ where
         T: Data<Elem = A>;
 
     private_decl! {}
-}
-
-macro_rules! return_err_if_empty {
-    ($arr:expr) => {
-        if $arr.len() == 0 {
-            return Err(MultiInputError::EmptyInput);
-        }
-    };
-}
-macro_rules! return_err_unless_same_shape {
-    ($arr_a:expr, $arr_b:expr) => {
-        if $arr_a.shape() != $arr_b.shape() {
-            return Err(ShapeMismatch {
-                first_shape: $arr_a.shape().to_vec(),
-                second_shape: $arr_b.shape().to_vec(),
-            }
-            .into());
-        }
-    };
 }
 
 impl<A, S, D> DeviationExt<A, S, D> for ArrayBase<S, D>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,29 @@ pub use crate::sort::Sort1dExt;
 pub use crate::summary_statistics::SummaryStatisticsExt;
 
 #[macro_use]
+mod multi_input_error_macros {
+    macro_rules! return_err_if_empty {
+        ($arr:expr) => {
+            if $arr.len() == 0 {
+                return Err(MultiInputError::EmptyInput);
+            }
+        };
+    }
+    macro_rules! return_err_unless_same_shape {
+        ($arr_a:expr, $arr_b:expr) => {
+            use crate::errors::{MultiInputError, ShapeMismatch};
+            if $arr_a.shape() != $arr_b.shape() {
+                return Err(MultiInputError::ShapeMismatch(ShapeMismatch {
+                    first_shape: $arr_a.shape().to_vec(),
+                    second_shape: $arr_b.shape().to_vec(),
+                })
+                .into());
+            }
+        };
+    }
+}
+
+#[macro_use]
 mod private {
     /// This is a public type in a private module, so it can be included in
     /// public APIs, but other crates can't access it.

--- a/src/summary_statistics/means.rs
+++ b/src/summary_statistics/means.rs
@@ -54,7 +54,8 @@ where
         D: RemoveAxis,
     {
         let mut weighted_sum = self.weighted_sum_axis(axis, weights)?;
-        weighted_sum.mapv_inplace(|v| v / weights.sum());
+        let weights_sum = weights.sum();
+        weighted_sum.mapv_inplace(|v| v / weights_sum);
         Ok(weighted_sum)
     }
 

--- a/src/summary_statistics/means.rs
+++ b/src/summary_statistics/means.rs
@@ -26,7 +26,7 @@ where
 
     fn weighted_mean(&self, weights: &Self) -> Result<A, MultiInputError>
     where
-        A: Copy + Div<Output = A> + Mul<Output = A> + Zero
+        A: Copy + Div<Output = A> + Mul<Output = A> + Zero,
     {
         let weighted_sum = self.weighted_sum(weights)?;
         Ok(weighted_sum / weights.sum())
@@ -51,7 +51,7 @@ where
     ) -> Result<Array<A, D::Smaller>, MultiInputError>
     where
         A: Copy + Div<Output = A> + Mul<Output = A> + Zero,
-        D: RemoveAxis
+        D: RemoveAxis,
     {
         let mut weighted_sum = self.weighted_sum_axis(axis, weights)?;
         weighted_sum.mapv_inplace(|v| v / weights.sum());
@@ -261,7 +261,13 @@ mod tests {
     fn test_means_with_nan_values() {
         let a = array![f64::NAN, 1.];
         assert!(a.mean().unwrap().is_nan());
+        assert!(a.weighted_mean(&array![1.0, f64::NAN]).unwrap().is_nan());
         assert!(a.weighted_sum(&array![1.0, f64::NAN]).unwrap().is_nan());
+        assert!(a
+            .weighted_mean_axis(Axis(0), &array![1.0, f64::NAN])
+            .unwrap()
+            .into_scalar()
+            .is_nan());
         assert!(a
             .weighted_sum_axis(Axis(0), &array![1.0, f64::NAN])
             .unwrap()
@@ -276,7 +282,15 @@ mod tests {
         let a: Array1<f64> = array![];
         assert_eq!(a.mean(), Err(EmptyInput));
         assert_eq!(
+            a.weighted_mean(&array![1.0]),
+            Err(MultiInputError::EmptyInput)
+        );
+        assert_eq!(
             a.weighted_sum(&array![1.0]),
+            Err(MultiInputError::EmptyInput)
+        );
+        assert_eq!(
+            a.weighted_mean_axis(Axis(0), &array![1.0]),
             Err(MultiInputError::EmptyInput)
         );
         assert_eq!(
@@ -291,7 +305,12 @@ mod tests {
     fn test_means_with_empty_array_of_noisy_floats() {
         let a: Array1<N64> = array![];
         assert_eq!(a.mean(), Err(EmptyInput));
+        assert_eq!(a.weighted_mean(&array![]), Err(MultiInputError::EmptyInput));
         assert_eq!(a.weighted_sum(&array![]), Err(MultiInputError::EmptyInput));
+        assert_eq!(
+            a.weighted_mean_axis(Axis(0), &array![]),
+            Err(MultiInputError::EmptyInput)
+        );
         assert_eq!(
             a.weighted_sum_axis(Axis(0), &array![]),
             Err(MultiInputError::EmptyInput)
@@ -340,14 +359,34 @@ mod tests {
         );
 
         let data = a.into_shape((2, 5, 5)).unwrap();
-        let weights = array![0.1, 0.3, 0.25, 0.15, 0.2];
+        let weights = array![0.1, 0.5, 0.25, 0.15, 0.2];
+        assert!(data
+            .weighted_mean_axis(Axis(1), &weights)
+            .unwrap()
+            .all_close(
+                &array![
+                    [0.50202721, 0.53347361, 0.29086033, 0.56995637, 0.37087139],
+                    [0.58028328, 0.50485216, 0.59349973, 0.70308937, 0.72280630]
+                ],
+                1e-8
+            ));
+        assert!(data
+            .weighted_mean_axis(Axis(2), &weights)
+            .unwrap()
+            .all_close(
+                &array![
+                    [0.33434378, 0.38365259, 0.56405781, 0.48676574, 0.55016179],
+                    [0.71112376, 0.55134174, 0.45566513, 0.74228516, 0.68405851]
+                ],
+                1e-8
+            ));
         assert!(data
             .weighted_sum_axis(Axis(1), &weights)
             .unwrap()
             .all_close(
                 &array![
-                    [0.44101183, 0.55664246, 0.30327354, 0.59595320, 0.39738206],
-                    [0.56957640, 0.56098049, 0.57067907, 0.64527520, 0.70696926]
+                    [0.60243266, 0.64016833, 0.34903240, 0.68394765, 0.44504567],
+                    [0.69633993, 0.60582259, 0.71219968, 0.84370724, 0.86736757]
                 ],
                 1e-8
             ));
@@ -356,43 +395,45 @@ mod tests {
             .unwrap()
             .all_close(
                 &array![
-                    [0.39819792, 0.37685724, 0.55147013, 0.45484881, 0.48404941],
-                    [0.69563747, 0.61676800, 0.42408611, 0.72082281, 0.68683798]
+                    [0.40121254, 0.46038311, 0.67686937, 0.58411889, 0.66019415],
+                    [0.85334851, 0.66161009, 0.54679815, 0.89074219, 0.82087021]
                 ],
                 1e-8
             ));
     }
 
     #[test]
-    fn mean_eq_weighted_mean_if_uniform_weights() {
+    fn mean_eq_if_uniform_weights() {
         fn prop(a: Vec<f64>) -> TestResult {
             if a.len() < 1 {
                 return TestResult::discard();
             }
             let a = Array1::from_vec(a);
             let weights = Array1::from_elem(a.len(), 1.0 / a.len() as f64);
-            TestResult::from_bool(abs_diff_eq!(
-                a.weighted_sum(&weights).unwrap(),
-                a.mean().unwrap(),
-                epsilon = 1e-9
-            ))
+            let m = a.mean().unwrap();
+            let wm = a.weighted_mean(&weights).unwrap();
+            let ws = a.weighted_sum(&weights).unwrap();
+            TestResult::from_bool(
+                abs_diff_eq!(m, wm, epsilon = 1e-9) && abs_diff_eq!(wm, ws, epsilon = 1e-9),
+            )
         }
         quickcheck(prop as fn(Vec<f64>) -> TestResult);
     }
 
     #[test]
-    fn mean_axis_eq_weighted_mean_axis_if_uniform_weights() {
+    fn mean_axis_eq_if_uniform_weights() {
         fn prop(mut a: Vec<f64>) -> TestResult {
             if a.len() < 24 {
                 return TestResult::discard();
             }
-            a.truncate(24);
-            let a = Array1::from_vec(a).into_shape((2, 3, 4)).unwrap();
-            TestResult::from_bool(
-                a.weighted_sum_axis(Axis(0), &array![0.5, 0.5])
-                    .unwrap()
-                    .all_close(&a.mean_axis(Axis(0)), 1e-12),
-            )
+            let depth = a.len() / 12;
+            a.truncate(depth * 3 * 4);
+            let weights = Array1::from_elem(depth, 1.0 / depth as f64);
+            let a = Array1::from_vec(a).into_shape((depth, 3, 4)).unwrap();
+            let ma = a.mean_axis(Axis(0));
+            let wm = a.weighted_mean_axis(Axis(0), &weights).unwrap();
+            let ws = a.weighted_sum_axis(Axis(0), &weights).unwrap();
+            TestResult::from_bool(ma.all_close(&wm, 1e-12) && wm.all_close(&ws, 1e-12))
         }
         quickcheck(prop as fn(Vec<f64>) -> TestResult);
     }

--- a/src/summary_statistics/means.rs
+++ b/src/summary_statistics/means.rs
@@ -1,9 +1,9 @@
 use super::SummaryStatisticsExt;
-use crate::errors::EmptyInput;
+use crate::errors::{EmptyInput, MultiInputError};
 use ndarray::{ArrayBase, Data, Dimension};
 use num_integer::IterBinomial;
 use num_traits::{Float, FromPrimitive, Zero};
-use std::ops::{Add, Div};
+use std::ops::{Add, Div, Mul};
 
 impl<A, S, D> SummaryStatisticsExt<A, S, D> for ArrayBase<S, D>
 where
@@ -22,6 +22,18 @@ where
                 .expect("Converting number of elements to `A` must not fail.");
             Ok(self.sum() / n_elements)
         }
+    }
+
+    fn weighted_mean(&self, weights: &ArrayBase<S, D>) -> Result<A, MultiInputError>
+    where
+        A: Copy + Mul<Output = A> + Zero,
+    {
+        return_err_if_empty!(self);
+        return_err_unless_same_shape!(self, weights);
+        Ok(self
+            .iter()
+            .zip(weights)
+            .fold(A::zero(), |acc, (&d, &w)| acc + d * w))
     }
 
     fn harmonic_mean(&self) -> Result<A, EmptyInput>

--- a/src/summary_statistics/means.rs
+++ b/src/summary_statistics/means.rs
@@ -28,6 +28,7 @@ where
     where
         A: Copy + Div<Output = A> + Mul<Output = A> + Zero,
     {
+        return_err_if_empty!(self);
         let weighted_sum = self.weighted_sum(weights)?;
         Ok(weighted_sum / weights.sum())
     }
@@ -36,7 +37,6 @@ where
     where
         A: Copy + Mul<Output = A> + Zero,
     {
-        return_err_if_empty!(self);
         return_err_unless_same_shape!(self, weights);
         Ok(self
             .iter()
@@ -53,6 +53,7 @@ where
         A: Copy + Div<Output = A> + Mul<Output = A> + Zero,
         D: RemoveAxis,
     {
+        return_err_if_empty!(self);
         let mut weighted_sum = self.weighted_sum_axis(axis, weights)?;
         let weights_sum = weights.sum();
         weighted_sum.mapv_inplace(|v| v / weights_sum);
@@ -68,7 +69,6 @@ where
         A: Copy + Mul<Output = A> + Zero,
         D: RemoveAxis,
     {
-        return_err_if_empty!(self);
         if self.shape()[axis.index()] != weights.len() {
             return Err(MultiInputError::ShapeMismatch(ShapeMismatch {
                 first_shape: self.shape().to_vec(),

--- a/src/summary_statistics/mod.rs
+++ b/src/summary_statistics/mod.rs
@@ -28,13 +28,17 @@ where
     where
         A: Clone + FromPrimitive + Add<Output = A> + Div<Output = A> + Zero;
 
-    /// Returns the [`arithmetic weighted mean`] x̅ of all elements in the array. Assumes that the
-    /// weights are already normalized.
+    /// Returns the [`arithmetic weighted mean`] x̅ of all elements in the array. Use `weighted_sum`
+    /// if the `weights` are normalized (they sum up to 1.0).
     ///
     /// ```text
-    ///      n
-    /// x̅ =  ∑ xᵢwᵢ
-    ///     i=1
+    ///       n
+    ///       ∑ wᵢxᵢ
+    ///      i=1
+    /// x̅ = ―――――――――
+    ///        n
+    ///        ∑ wᵢ
+    ///       i=1
     /// ```
     ///
     /// The following **errors** may be returned:
@@ -45,15 +49,31 @@ where
     /// [`arithmetic weighted mean`] https://en.wikipedia.org/wiki/Weighted_arithmetic_mean
     fn weighted_mean(&self, weights: &Self) -> Result<A, MultiInputError>
     where
-        A: Copy + Mul<Output = A> + Zero;
+        A: Copy + Div<Output = A> + Mul<Output = A> + Zero;
 
-    /// Returns the [`arithmetic weighted mean`] x̅ along `axis`. Assumes that the weights are
-    /// already normalized.
+    /// Like `weighted_mean`, but assumes that the `weights` are normalized. In that case, this
+    /// function is identical to `weighted_mean`. See its documentation for more information.
     ///
     /// ```text
     ///      n
-    /// x̅ =  ∑ xᵢwᵢ
+    /// x̅ =  ∑ wᵢxᵢ
     ///     i=1
+    /// ```
+    fn weighted_sum(&self, weights: &Self) -> Result<A, MultiInputError>
+    where
+        A: Copy + Mul<Output = A> + Zero;
+
+    /// Returns the [`arithmetic weighted mean`] x̅ along `axis`. Use `weighted_mean_axis ` if the
+    /// `weights` are normalized.
+    ///
+    /// ```text
+    ///       n
+    ///       ∑ wᵢxᵢ
+    ///      i=1
+    /// x̅ = ―――――――――
+    ///        n
+    ///        ∑ wᵢ
+    ///       i=1
     /// ```
     ///
     /// The following **errors** may be returned:
@@ -63,6 +83,23 @@ where
     ///
     /// [`arithmetic weighted mean`] https://en.wikipedia.org/wiki/Weighted_arithmetic_mean
     fn weighted_mean_axis(
+        &self,
+        axis: Axis,
+        weights: &ArrayBase<S, Ix1>,
+    ) -> Result<Array<A, D::Smaller>, MultiInputError>
+    where
+        A: Copy + Div<Output = A> + Mul<Output = A> + Zero,
+        D: RemoveAxis;
+
+    /// Like `weighted_mean_axis`, but assumes that the `weights` are normalized. In that case, this
+    /// function is identical to `weighted_mean_axis`. See its documentation for more information.
+    ///
+    /// ```text
+    ///      n
+    /// x̅ =  ∑ wᵢxᵢ
+    ///     i=1
+    /// ```
+    fn weighted_sum_axis(
         &self,
         axis: Axis,
         weights: &ArrayBase<S, Ix1>,

--- a/src/summary_statistics/mod.rs
+++ b/src/summary_statistics/mod.rs
@@ -1,6 +1,6 @@
 //! Summary statistics (e.g. mean, variance, etc.).
 use crate::errors::{EmptyInput, MultiInputError};
-use ndarray::{Data, Dimension};
+use ndarray::{Array, ArrayBase, Axis, Data, Dimension, Ix1, RemoveAxis};
 use num_traits::{Float, FromPrimitive, Zero};
 use std::ops::{Add, Div, Mul};
 
@@ -28,7 +28,7 @@ where
     where
         A: Clone + FromPrimitive + Add<Output = A> + Div<Output = A> + Zero;
 
-    /// Returns the [`arithmetic weighted mean`] x̅ of all elements in the array: Assumes that the
+    /// Returns the [`arithmetic weighted mean`] x̅ of all elements in the array. Assumes that the
     /// weights are already normalized.
     ///
     /// ```text
@@ -46,6 +46,30 @@ where
     fn weighted_mean(&self, weights: &Self) -> Result<A, MultiInputError>
     where
         A: Copy + Mul<Output = A> + Zero;
+
+    /// Returns the [`arithmetic weighted mean`] x̅ along `axis`. Assumes that the weights are
+    /// already normalized.
+    ///
+    /// ```text
+    ///      n
+    /// x̅ =  ∑ xᵢwᵢ
+    ///     i=1
+    /// ```
+    ///
+    /// The following **errors** may be returned:
+    ///
+    /// * `MultiInputError::EmptyInput` if `self` is empty
+    /// * `MultiInputError::ShapeMismatch` if `self` length along axis is not equal to `weights` length
+    ///
+    /// [`arithmetic weighted mean`] https://en.wikipedia.org/wiki/Weighted_arithmetic_mean
+    fn weighted_mean_axis(
+        &self,
+        axis: Axis,
+        weights: &ArrayBase<S, Ix1>,
+    ) -> Result<Array<A, D::Smaller>, MultiInputError>
+    where
+        A: Copy + Mul<Output = A> + Zero,
+        D: RemoveAxis;
 
     /// Returns the [`harmonic mean`] `HM(X)` of all elements in the array:
     ///

--- a/src/summary_statistics/mod.rs
+++ b/src/summary_statistics/mod.rs
@@ -1,8 +1,8 @@
 //! Summary statistics (e.g. mean, variance, etc.).
-use crate::errors::EmptyInput;
+use crate::errors::{EmptyInput, MultiInputError};
 use ndarray::{Data, Dimension};
 use num_traits::{Float, FromPrimitive, Zero};
-use std::ops::{Add, Div};
+use std::ops::{Add, Div, Mul};
 
 /// Extension trait for `ArrayBase` providing methods
 /// to compute several summary statistics (e.g. mean, variance, etc.).
@@ -27,6 +27,25 @@ where
     fn mean(&self) -> Result<A, EmptyInput>
     where
         A: Clone + FromPrimitive + Add<Output = A> + Div<Output = A> + Zero;
+
+    /// Returns the [`arithmetic weighted mean`] x̅ of all elements in the array: Assumes that the
+    /// weights are already normalized.
+    ///
+    /// ```text
+    ///      n
+    /// x̅ =  ∑ xᵢwᵢ
+    ///     i=1
+    /// ```
+    ///
+    /// The following **errors** may be returned:
+    ///
+    /// * `MultiInputError::EmptyInput` if `self` is empty
+    /// * `MultiInputError::ShapeMismatch` if `self` and `weights` don't have the same shape
+    ///
+    /// [`arithmetic weighted mean`] https://en.wikipedia.org/wiki/Weighted_arithmetic_mean
+    fn weighted_mean(&self, weights: &Self) -> Result<A, MultiInputError>
+    where
+        A: Copy + Mul<Output = A> + Zero;
 
     /// Returns the [`harmonic mean`] `HM(X)` of all elements in the array:
     ///

--- a/src/summary_statistics/mod.rs
+++ b/src/summary_statistics/mod.rs
@@ -41,6 +41,8 @@ where
     ///       i=1
     /// ```
     ///
+    /// **Panics** if division by zero panics for type A.
+    ///
     /// The following **errors** may be returned:
     ///
     /// * `MultiInputError::EmptyInput` if `self` is empty
@@ -51,14 +53,18 @@ where
     where
         A: Copy + Div<Output = A> + Mul<Output = A> + Zero;
 
-    /// Like `weighted_mean`, but assumes that the `weights` are normalized. In that case, this
-    /// function is identical to `weighted_mean`. See its documentation for more information.
+    /// Returns the weighted sum of all elements in the array, that is, the dot product of the
+    /// arrays `self` and `weights`. Equivalent to `weighted_mean` if the `weights` are normalized.
     ///
     /// ```text
     ///      n
     /// x̅ =  ∑ wᵢxᵢ
     ///     i=1
     /// ```
+    ///
+    /// The following **errors** may be returned:
+    ///
+    /// * `MultiInputError::ShapeMismatch` if `self` and `weights` don't have the same shape
     fn weighted_sum(&self, weights: &Self) -> Result<A, MultiInputError>
     where
         A: Copy + Mul<Output = A> + Zero;
@@ -76,6 +82,8 @@ where
     ///       i=1
     /// ```
     ///
+    /// **Panics** if `axis` is out of bounds.
+    ///
     /// The following **errors** may be returned:
     ///
     /// * `MultiInputError::EmptyInput` if `self` is empty
@@ -91,14 +99,20 @@ where
         A: Copy + Div<Output = A> + Mul<Output = A> + Zero,
         D: RemoveAxis;
 
-    /// Like `weighted_mean_axis`, but assumes that the `weights` are normalized. In that case, this
-    /// function is identical to `weighted_mean_axis`. See its documentation for more information.
+    /// Returns the weighted sum along `axis`, that is, the dot product of `weights` and each lane
+    /// of `self` along `axis`. Equivalent to `weighted_mean_axis` if the `weights` are normalized.
     ///
     /// ```text
     ///      n
     /// x̅ =  ∑ wᵢxᵢ
     ///     i=1
     /// ```
+    ///
+    /// **Panics** if `axis` is out of bounds.
+    ///
+    /// The following **errors** may be returned
+    ///
+    /// * `MultiInputError::ShapeMismatch` if `self` and `weights` don't have the same shape
     fn weighted_sum_axis(
         &self,
         axis: Axis,


### PR DESCRIPTION
Here's a first version of `weighted_mean` and `weighted_mean_axis`. 

Disclaimers:

1. I don't really know where `weighted_mean` and friends  should go. Is `summary_statistics` ok?
2. I had to move `return_err_if_empty` and `return_err_unless_same_shape` because ther are useful elsewhere.
3. There's a little code-copy in `weighted_mean_axis`, to avoid `(2 conditions + 1 unwrap) x nb_lanes`. Maybe I could create an inner function called `inner_weighted_mean` or something, then call it in both functions?

Questions:

1. Why are the `summary_statistics` tests (and others) not in `/tests/*`? I thought that the public API was supposed to be tested outside the crate. Is this not a "standard"?