### PR TITLE
Remove redundant call to abs in sq_l2_dist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ harness = false
 [[bench]]
 name = "summary_statistics"
 harness = false
+
+[[bench]]
+name = "deviation"
+harness = false

--- a/benches/deviation.rs
+++ b/benches/deviation.rs
@@ -1,0 +1,31 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, AxisScale, Criterion, ParameterizedBenchmark,
+    PlotConfiguration,
+};
+use ndarray::prelude::*;
+use ndarray_rand::RandomExt;
+use ndarray_stats::DeviationExt;
+use rand::distributions::Uniform;
+
+fn sq_l2_dist(c: &mut Criterion) {
+    let lens = vec![10, 100, 1000, 10000];
+    let benchmark = ParameterizedBenchmark::new(
+        "sq_l2_dist",
+        |bencher, &len| {
+            let data = Array::random(len, Uniform::new(0.0, 1.0));
+            let data2 = Array::random(len, Uniform::new(0.0, 1.0));
+
+            bencher.iter(|| black_box(data.sq_l2_dist(&data2).unwrap()))
+        },
+        lens,
+    )
+    .plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+    c.bench("sq_l2_dist", benchmark);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = sq_l2_dist
+}
+criterion_main!(benches);

--- a/src/deviation.rs
+++ b/src/deviation.rs
@@ -261,8 +261,8 @@ where
 
         Zip::from(self).and(other).apply(|self_i, other_i| {
             let (a, b) = (self_i.clone(), other_i.clone());
-            let abs_diff = (a - b).abs();
-            result += abs_diff.clone() * abs_diff;
+            let diff = a - b;
+            result += diff.clone() * diff;
         });
 
         Ok(result)


### PR DESCRIPTION
# What?

Removes a redundant call to `abs` in `sq_l2_dist`.

# Why?

Calling `abs` is unnecessary, as the difference is squared immediately afterwards, which always results in a positive number.

# Impact?

For simple `Copy` scalar types, benchmarking showed no consistent performance difference. So the only impact is code reduction / simplification.

Even though we support `Clone` types the only type in any way supported right now is `num-bigint`. I tried to benchmark this to see if that showed a performance improvement, but gave up due to dependency version incompatibilities between `num-bigint` and `ndarray-*`.

Currently, the module does not work at all with `num-complex`, so there is no cost in this respect.