### PR TITLE
clippy and a bugfix

### DIFF
--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -133,7 +133,7 @@ where
     where
         A: Float,
     {
-        if self.len() == 0 {
+        if self.is_empty() {
             Err(EmptyInput)
         } else {
             let entropy = -self
@@ -154,7 +154,7 @@ where
         A: Float,
         S2: Data<Elem = A>,
     {
-        if self.len() == 0 {
+        if self.is_empty() {
             return Err(MultiInputError::EmptyInput);
         }
         if self.shape() != q.shape() {
@@ -187,7 +187,7 @@ where
         S2: Data<Elem = A>,
         A: Float,
     {
-        if self.len() == 0 {
+        if self.is_empty() {
             return Err(MultiInputError::EmptyInput);
         }
         if self.shape() != q.shape() {

--- a/src/histogram/bins.rs
+++ b/src/histogram/bins.rs
@@ -123,6 +123,23 @@ impl<A: Ord> Edges<A> {
         self.edges.len()
     }
 
+    /// Returns `true` if `self` contains no edges.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// use ndarray_stats::histogram::Edges;
+    /// use noisy_float::types::{N64, n64};
+    ///
+    /// let edges = Edges::<N64>::from(vec![]);
+    /// assert_eq!(edges.is_empty(), true);
+    /// let edges = Edges::from(vec![n64(0.), n64(2.), n64(5.)]);
+    /// assert_eq!(edges.is_empty(), false);
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.edges.is_empty()
+    }
+
     /// Borrow an immutable reference to the edges as a 1-dimensional
     /// array view.
     ///
@@ -238,6 +255,29 @@ impl<A: Ord> Bins<A> {
             0 => 0,
             n => n - 1,
         }
+    }
+
+    /// Returns `true` if the number of bins is zero, or in other words, if the
+    /// number of edges is 0 or 1.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// use ndarray_stats::histogram::{Edges, Bins};
+    /// use noisy_float::types::{N64, n64};
+    ///
+    /// let edges = Edges::<N64>::from(vec![]);
+    /// let bins = Bins::new(edges);
+    /// assert_eq!(bins.is_empty(), true);
+    /// let edges = Edges::from(vec![n64(0.)]);
+    /// let bins = Bins::new(edges);
+    /// assert_eq!(bins.is_empty(), true);
+    /// let edges = Edges::from(vec![n64(0.), n64(1.), n64(3.)]);
+    /// let bins = Bins::new(edges);
+    /// assert_eq!(bins.is_empty(), false);
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Given `value`, it returns:

--- a/src/histogram/strategies.rs
+++ b/src/histogram/strategies.rs
@@ -171,7 +171,7 @@ where
     fn build(&self) -> Bins<T> {
         let n_bins = self.n_bins();
         let mut edges: Vec<T> = vec![];
-        for i in 0..(n_bins + 1) {
+        for i in 0..=n_bins {
             let edge = self.min.clone() + T::from_usize(i).unwrap() * self.bin_width.clone();
             edges.push(edge);
         }
@@ -185,7 +185,7 @@ where
             max_edge = max_edge + self.bin_width.clone();
             n_bins += 1;
         }
-        return n_bins;
+        n_bins
     }
 
     fn bin_width(&self) -> T {
@@ -361,8 +361,7 @@ where
 {
     fn compute_bin_width(n_bins: usize, iqr: T) -> T {
         let denominator = (n_bins as f64).powf(1. / 3.);
-        let bin_width = T::from_usize(2).unwrap() * iqr / T::from_f64(denominator).unwrap();
-        bin_width
+        T::from_usize(2).unwrap() * iqr / T::from_f64(denominator).unwrap()
     }
 
     /// The bin width (or bin length) according to the fitted strategy.
@@ -449,8 +448,7 @@ where
     T: Ord + Clone + FromPrimitive + NumOps + Zero,
 {
     let range = max.clone() - min.clone();
-    let bin_width = range / T::from_usize(n_bins).unwrap();
-    bin_width
+    range / T::from_usize(n_bins).unwrap()
 }
 
 #[cfg(test)]

--- a/src/maybe_nan/impl_not_none.rs
+++ b/src/maybe_nan/impl_not_none.rs
@@ -35,9 +35,6 @@ impl<T: PartialEq> PartialEq for NotNone<T> {
     fn eq(&self, other: &Self) -> bool {
         self.deref().eq(other)
     }
-    fn ne(&self, other: &Self) -> bool {
-        self.deref().eq(other)
-    }
 }
 
 impl<T: Ord> Ord for NotNone<T> {

--- a/src/maybe_nan/mod.rs
+++ b/src/maybe_nan/mod.rs
@@ -43,7 +43,7 @@ pub trait MaybeNan: Sized {
 ///
 /// This modifies the input view by moving elements as necessary.
 fn remove_nan_mut<A: MaybeNan>(mut view: ArrayViewMut1<'_, A>) -> ArrayViewMut1<'_, A> {
-    if view.len() == 0 {
+    if view.is_empty() {
         return view.slice_move(s![..0]);
     }
     let mut i = 0;

--- a/src/summary_statistics/means.rs
+++ b/src/summary_statistics/means.rs
@@ -288,7 +288,7 @@ where
 {
     let n_elements =
         A::from_usize(a.len()).expect("Converting number of elements to `A` must not fail");
-    let order = order as i32;
+    let order = i32::from(order);
 
     // When k=0, we are raising each element to the 0th power
     // No need to waste CPU cycles going through the array


### PR DESCRIPTION
Fixed most clippy warnings. Two remain but appear to be in the ndarray `s![]` macro itself.

One warning highlighted that the `ne()` implementation for `NotNone` which actually called `eq()` on the inner field. A default implementation of `ne()` is implied by `eq()`, so the buggy implementation could simply be removed.