### PR TITLE
Update changelog and version for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndarray-stats"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jim Turner <ndarray-stats@turner.link>", "LukeMathWalker <rust@lpalmieri.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ ndarray-stats = "0.4"
 
 ## Releases
 
+* **0.5.0**
+  * Breaking changes
+    * Minimum supported Rust version: `1.49.0`
+    * Updated to `ndarray:v0.15.0`
+
+  *Contributors*: [@Armavica](https://github.com/armavica), [@cassiersg](https://github.com/cassiersg)
+
 * **0.4.0**
   * Breaking changes
     * Minimum supported Rust version: `1.42.0`


### PR DESCRIPTION
New ndarray version, new release! Only dependencies have changed for this one but it does add breaking changes due to new ndarray and minimum supported rust version moving up to match ndarray 0.15.