### PR TITLE
Fix signed integer overflow with midpoint interpolation

### DIFF
--- a/src/maybe_nan/impl_not_none.rs
+++ b/src/maybe_nan/impl_not_none.rs
@@ -1,5 +1,5 @@
 use super::NotNone;
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_traits::{Euclid, FromPrimitive, ToPrimitive};
 use std::cmp;
 use std::fmt;
 use std::ops::{Add, Deref, DerefMut, Div, Mul, Rem, Sub};
@@ -98,6 +98,19 @@ impl<T: Rem> Rem for NotNone<T> {
     #[inline]
     fn rem(self, rhs: Self) -> Self::Output {
         self.map(|v| v.rem(rhs.unwrap()))
+    }
+}
+
+impl<T: Euclid> Euclid for NotNone<T> {
+    #[inline]
+    fn div_euclid(&self, rhs: &Self) -> Self {
+        let result = self.deref().div_euclid(rhs.deref());
+        NotNone(Some(result))
+    }
+    #[inline]
+    fn rem_euclid(&self, rhs: &Self) -> Self {
+        let result = self.deref().rem_euclid(rhs.deref());
+        NotNone(Some(result))
     }
 }
 

--- a/tests/quantile.rs
+++ b/tests/quantile.rs
@@ -268,12 +268,22 @@ fn test_quantile_axis_skipnan_mut_linear_opt_i32() {
 }
 
 #[test]
-fn test_midpoint_overflow() {
+fn test_midpoint_overflow_unsigned() {
     // Regression test
     // This triggered an overflow panic with a naive Midpoint implementation: (a+b)/2
     let mut a: Array1<u8> = array![129, 130, 130, 131];
     let median = a.quantile_mut(n64(0.5), &Midpoint).unwrap();
     let expected_median = 130;
+    assert_eq!(median, expected_median);
+}
+
+#[test]
+fn test_midpoint_overflow_signed() {
+    // Regression test
+    // This triggered an overflow panic with a naive Midpoint implementation: b+(a-b)/2
+    let mut a: Array1<i64> = array![i64::MIN, i64::MAX];
+    let median = a.quantile_mut(n64(0.5), &Midpoint).unwrap();
+    let expected_median = -1;
     assert_eq!(median, expected_median);
 }
 


### PR DESCRIPTION
I found this while exploring whether QuickCheck could be updated. Its newer version seems to run more thorough testing, which revealed this problem among others.

---

<details>
<summary>Assembly comparison</summary>

The new algorithm is not really much more complex than the original when comparing the assembly.

I checked the [Compiler Explorer](https://rust.godbolt.org/) results for the following simplified versions, using `-C opt-level=1` for compiler option:

```rust
#[unsafe(no_mangle)]
pub fn naive_midpoint_i64(lower: i64, higher: i64) -> i64 {
    lower + (higher - lower) / 2
}
```

```rust
#[unsafe(no_mangle)]
pub fn interpolate(lower: i64, higher: i64) -> i64 {
    let (lower_half, lower_rem) = (lower.div_euclid(2), lower.rem_euclid(2));
    let (higher_half, higher_rem) = (higher.div_euclid(2), higher.rem_euclid(2));
    lower_half + higher_half + (lower_rem * higher_rem)
}
```

The old algorithm produces the following assembly:
```assembly
naive_midpoint_i64:
        sub     rsi, rdi
        mov     rax, rsi
        shr     rax, 63
        add     rax, rsi
        sar     rax
        add     rax, rdi
        ret
```

The new algorithm produces the following:
```assembly
interpolate:
        mov     rcx, rdi
        sar     rcx
        and     edi, esi
        mov     rax, rsi
        sar     rax
        add     rax, rcx
        and     edi, 1
        add     rax, rdi
        ret
```

So it seems the new algorithm is two instructions longer.

</details>

I ran additional testing locally with the following command to ensure the changed algorithm returns the exact same results as the previous one:

```
QUICKCHECK_TESTS=100000000 cargo test --lib test_midpoint_algo_eq_naive_algo_i64
```

Something I'm a bit unsure about is whether there are any additional types `Midpoint` should be implemented for.